### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Latest Version](https://pypip.in/version/cmsplugin_instagram/badge.svg)](https://pypi.python.org/pypi/cmsplugin-instagram/)
-[![Supported Python versions](https://pypip.in/py_versions/cmsplugin_instagram/badge.svg)](https://pypi.python.org/pypi/cmsplugin-instagram/)
-[![Development Status](https://pypip.in/status/cmsplugin_instagram/badge.svg)](https://pypi.python.org/pypi/cmsplugin_instagram/)
+[![Latest Version](https://img.shields.io/pypi/v/cmsplugin_instagram.svg)](https://pypi.python.org/pypi/cmsplugin-instagram/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/cmsplugin_instagram.svg)](https://pypi.python.org/pypi/cmsplugin-instagram/)
+[![Development Status](https://img.shields.io/pypi/status/cmsplugin_instagram.svg)](https://pypi.python.org/pypi/cmsplugin_instagram/)
 [![Code Climate](https://codeclimate.com/github/creimers/cmsplugin_instagram/badges/gpa.svg)](https://codeclimate.com/github/creimers/cmsplugin_instagram)
 # djangocms instagram plugin
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cmsplugin-instagram))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cmsplugin-instagram`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.